### PR TITLE
.boguignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build
 .archives
 install.sh
 scripts/
+.boguignore
+ignore.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && wget https://github.com/bogu-io/bogu/releases/download/0.0.15/bogu-0.0.15-linux-x64.zip \
-    && unzip bogu-0.0.15-linux-x64.zip
+    && wget https://github.com/bogu-io/bogu/releases/download/0.0.16/bogu-0.0.16-linux-x64.zip \
+    && unzip bogu-0.0.16-linux-x64.zip
 # EXPOSE 8080
-ENTRYPOINT [ "bogu-0.0.15/bin/bogu" ]
+ENTRYPOINT [ "bogu-0.0.16/bin/bogu" ]
 CMD [ "--version" ]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ bogu: bogu.rkt \
 	  github.rkt \
 	  github-api.rkt \
 	  utils.rkt \
-	  format.rkt
+	  format.rkt \
+	  ignore.rkt
 	raco exe bogu.rkt
 	raco distribute build bogu
 
@@ -22,7 +23,8 @@ bogu-darwin-arm64: bogu.rkt \
 				   github.rkt \
 				   github-api.rkt \
 				   utils.rkt \
-	  			   format.rkt
+	  			   format.rkt \
+				   ignore.rkt
 	raco exe -o bogu bogu.rkt
 	raco distribute bogu-$(BOGU_VERSION) bogu
 	# cp scripts/darwin/install.sh install.sh
@@ -38,7 +40,8 @@ bogu-linux-x64: bogu.rkt \
 				github.rkt \
 				github-api.rkt \
 				utils.rkt \
-	  			format.rkt
+	  			format.rkt \
+				ignore.rkt
 	raco exe -o bogu bogu.rkt
 	raco distribute bogu-$(BOGU_VERSION) bogu
 	# cp scripts/linux/install.sh install.sh

--- a/bogu.rkt
+++ b/bogu.rkt
@@ -13,6 +13,7 @@
   "utils.rkt")
 
 (define (main args)
+  (create-bogu-files)
   (displayln (string-append "Bogu " version-slug))
   (cond [(= (vector-length args) 0) (displayln help-text)])
   (cond [(> (string-length (local-path)) 0) (local-scan (local-path))])

--- a/ignore.rkt
+++ b/ignore.rkt
@@ -1,0 +1,26 @@
+#lang racket
+
+;; ignore.rkt - Ignore paths and files
+
+;; Ask and I shall provide
+(provide
+  (all-defined-out))
+
+;; —————————————————————————————————
+;; import and implementation section
+
+(define (read-ignore-patterns file-path)
+  (with-input-from-file file-path
+    (lambda ()
+      (filter (lambda (line) (not (empty? line)))
+              (file->lines)))))
+
+; Function to check if a path should be ignored
+(define (should-ignore? path patterns)
+  (ormap (lambda (pattern)
+           (regexp-match pattern path))
+         patterns))
+
+; Example usage:
+(define patterns (read-ignore-patterns "path/to/.gitignore-like"))
+(should-ignore? "example.log" patterns)  ; Usage with loaded patterns

--- a/ignore.rkt
+++ b/ignore.rkt
@@ -9,18 +9,22 @@
 ;; —————————————————————————————————
 ;; import and implementation section
 
+(require
+  "utils.rkt")
+
 (define (read-ignore-patterns file-path)
-  (with-input-from-file file-path
-    (lambda ()
-      (filter (lambda (line) (not (empty? line)))
-              (file->lines)))))
+  (define file-path-resolved (simplify-path (expand-home-path file-path)))
+  (cond [(file-exists? file-path-resolved)
+         (with-input-from-file file-path-resolved
+           (lambda ()
+             (filter (lambda (line) (not (empty? line)))
+                     (file->lines file-path-resolved))))]))
 
 ; Function to check if a path should be ignored
 (define (should-ignore? path patterns)
-  (ormap (lambda (pattern)
-           (regexp-match pattern path))
-         patterns))
+  (for/or ([pattern patterns])
+    (regexp-match? pattern path)))
 
 ; Example usage:
-(define patterns (read-ignore-patterns "path/to/.gitignore-like"))
-(should-ignore? "example.log" patterns)  ; Usage with loaded patterns
+; (define patterns (read-ignore-patterns "path/to/.gitignore-like"))
+; (should-ignore? "example.log" patterns)  ; Usage with loaded patterns

--- a/parser.rkt
+++ b/parser.rkt
@@ -13,6 +13,7 @@
 (define debug (make-parameter #f))
 (define github-owner (make-parameter ""))
 (define github-token (make-parameter ""))
+(define ignore-path (make-parameter ""))
 (define local-path (make-parameter ""))
 (define output-format (make-parameter ""))
 (define silent (make-parameter #f))
@@ -28,6 +29,7 @@
     #:once-each
     [("-p" "--path") PATH "Local scan path" (local-path PATH)]
     [("--github-owner") OWNER "GitHub Repo Scan by Owner" (github-owner OWNER)]
+    [("--ignore-path") FILE ".boguignore file path" (ignore-path FILE)]
     [("-d" "--debug") "Debug" (debug #t)]
     [("-v" "--verbose") "Verbose" (verbose #t)]
     [("-s" "--silent") "Silent" (silent #t)]

--- a/parser.rkt
+++ b/parser.rkt
@@ -29,7 +29,7 @@
     #:once-each
     [("-p" "--path") PATH "Local scan path" (local-path PATH)]
     [("--github-owner") OWNER "GitHub Repo Scan by Owner" (github-owner OWNER)]
-    [("--ignore-path") FILE ".boguignore file path" (ignore-path FILE)]
+    [("-i" "--ignore-path") FILE ".boguignore file path" (ignore-path FILE)]
     [("-d" "--debug") "Debug" (debug #t)]
     [("-v" "--verbose") "Verbose" (verbose #t)]
     [("-s" "--silent") "Silent" (silent #t)]

--- a/parser.rkt
+++ b/parser.rkt
@@ -9,11 +9,14 @@
 ;; —————————————————————————————————
 ;; import and implementation section
 
+(require
+  "utils.rkt")
+
 ; Parameters
 (define debug (make-parameter #f))
 (define github-owner (make-parameter ""))
 (define github-token (make-parameter ""))
-(define ignore-path (make-parameter ""))
+(define ignore-path (make-parameter "~/.bogu/boguignore"))
 (define local-path (make-parameter ""))
 (define output-format (make-parameter ""))
 (define silent (make-parameter #f))

--- a/strings-test.rkt
+++ b/strings-test.rkt
@@ -14,7 +14,7 @@
   rackunit)
 
 ;; Test for `version-slug`
-(check-equal? version-slug "v0.0.15")
+(check-equal? version-slug "v0.0.16")
 
 ;; Test for `scan-start-text`
 (check-equal? (scan-start-text "test") "\nStarting test scan...\n")

--- a/strings.rkt
+++ b/strings.rkt
@@ -9,7 +9,7 @@
 ;; —————————————————————————————————
 ;; import and implementation section
 
-(define version-slug "v0.0.15")
+(define version-slug "v0.0.16")
 
 (define help-text (format "Bogu - ~a
 The Secret Scanner

--- a/utils.rkt
+++ b/utils.rkt
@@ -9,6 +9,17 @@
 ;; —————————————————————————————————
 ;; import and implementation section
 
+(define (create-bogu-files)
+  (define path (build-path (find-system-path 'home-dir) ".bogu" "boguignore"))
+  (unless (file-exists? path)
+    (make-directory* (path-only path))
+    (call-with-output-file path void)))
+
+(define (expand-home-path path)
+  (if (string-prefix? path "~")
+      (string-replace path "~" (path->string (find-system-path 'home-dir)))
+      path))
+
 ;; Check if we have gcp service credentials file
 (define (gcp-service-credentials-file? file-path)
   (define file-contents (call-with-input-file file-path port->string))

--- a/walk.rkt
+++ b/walk.rkt
@@ -12,7 +12,8 @@
 (require
   "parser.rkt"
   "scanner.rkt"
-  "utils.rkt")
+  "utils.rkt"
+  "ignore.rkt")
 
 ; Holds the results of the scan
 (define local-scan-results '())
@@ -20,47 +21,49 @@
 ; Filesystem path walker
 (define (recurse-through-files path)
   (define path-objects (directory-list path #:build? #t))
+  (define ignore-patterns (read-ignore-patterns (ignore-path)))
   ; (cond [(debug) (printf "[path-objects]\n~a\n" path-objects)])
   (for ([path-object path-objects])
     (define path-object-string (path->string path-object))
-    (cond
-      [(directory-exists? path-object)
-        (cond [(not (silent)) (printf "Entering directory: ~a\n" path-object)])
-        (recurse-through-files path-object)]
-      [(file-exists? path-object)
-        (define found-secrets '())
-        (define secrets-found (make-hasheq))
-        (cond [(not (silent)) (printf "File: ~a\n" path-object-string)])
-        (cond [(gcp-service-credentials-file? path-object-string)
-               (begin
-                 (cond [(not (silent)) (printf "Found GCP service credentials file: ~a\n" path-object-string)])
-                 (hash-set! secrets-found 'path path-object-string)
-                 (hash-set! secrets-found 'results (list (hasheq 'gcp_service_credentials_file path-object-string)))
-                 (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results))))]
-              [(gcp-oauth-file? path-object-string)
-               (begin
-                 (cond [(not (silent)) (printf "Found GCP OAuth file: ~a\n" path-object-string)])
-                 (hash-set! secrets-found 'path path-object-string)
-                 (hash-set! secrets-found 'results (list (hasheq 'gcp_oauth_file path-object-string)))
-                 (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results))))]
-              [else
-                (begin
-                  (set! found-secrets (find-secrets path-object-string))
-                  (hash-set! secrets-found 'path path-object-string)
-                  (hash-set! secrets-found 'results found-secrets)
-                  (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results))))])
-        (cond
-          [(not (empty? (hash-ref secrets-found 'results)))
-           (set! local-scan-results (append local-scan-results (list secrets-found)))])]
-      [else
-        (cond [(not (silent)) (printf "Other: ~a\n" path-object-string)])
-        (define found-secrets (find-secrets path-object-string))
-        (define secrets-found (make-hasheq))
-        (hash-set! secrets-found 'path path-object-string)
-        (hash-set! secrets-found 'results found-secrets)
-        (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results)))
-        (cond
-          [(not (empty? found-secrets))
-           (set! local-scan-results (append local-scan-results (list secrets-found)))])])))
+    (cond [(not (should-ignore? path-object-string ignore-patterns))
+           (cond
+            [(directory-exists? path-object)
+              (cond [(not (silent)) (printf "Entering directory: ~a\n" path-object)])
+              (recurse-through-files path-object)]
+            [(file-exists? path-object)
+              (define found-secrets '())
+              (define secrets-found (make-hasheq))
+              (cond [(not (silent)) (printf "File: ~a\n" path-object-string)])
+              (cond [(gcp-service-credentials-file? path-object-string)
+                    (begin
+                      (cond [(not (silent)) (printf "Found GCP service credentials file: ~a\n" path-object-string)])
+                      (hash-set! secrets-found 'path path-object-string)
+                      (hash-set! secrets-found 'results (list (hasheq 'gcp_service_credentials_file path-object-string)))
+                      (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results))))]
+                    [(gcp-oauth-file? path-object-string)
+                    (begin
+                      (cond [(not (silent)) (printf "Found GCP OAuth file: ~a\n" path-object-string)])
+                      (hash-set! secrets-found 'path path-object-string)
+                      (hash-set! secrets-found 'results (list (hasheq 'gcp_oauth_file path-object-string)))
+                      (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results))))]
+                    [else
+                      (begin
+                        (set! found-secrets (find-secrets path-object-string))
+                        (hash-set! secrets-found 'path path-object-string)
+                        (hash-set! secrets-found 'results found-secrets)
+                        (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results))))])
+              (cond
+                [(not (empty? (hash-ref secrets-found 'results)))
+                (set! local-scan-results (append local-scan-results (list secrets-found)))])]
+            [else
+              (cond [(not (silent)) (printf "Other: ~a\n" path-object-string)])
+              (define found-secrets (find-secrets path-object-string))
+              (define secrets-found (make-hasheq))
+              (hash-set! secrets-found 'path path-object-string)
+              (hash-set! secrets-found 'results found-secrets)
+              (hash-set! secrets-found 'count (length (hash-ref secrets-found 'results)))
+              (cond
+                [(not (empty? found-secrets))
+                (set! local-scan-results (append local-scan-results (list secrets-found)))])])])))
 
 (define reset-scan (lambda () (set! local-scan-results '())))


### PR DESCRIPTION
By default bogu will look for the `.boguignore` file in `~/.bogu`.

An ignore file can also be specified using the `-i FILE` or `--ignore FILE` options.